### PR TITLE
update to alpine image, 3.9 did not exist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,19 @@
 FROM arm32v7/python:3.9-alpine
 
+RUN apk update \
+  && apk add --no-cache --virtual build-tools gcc g++ bash openssh git make \
+  && apk add --no-cache --virtual build-headers postgresql-dev python3-dev musl-dev jpeg-dev zlib-dev libffi-dev freetype-dev czmq-dev lcms2-dev openjpeg-dev tiff-dev tk-dev tcl-dev \
+  && apk add --no-cache --virtual runtime-deps busybox-extras czmq libzmq uwsgi-logzmq py-cffi gettext postgresql-client gnupg \
+  && python -m pip install --upgrade pip \
+  && pip install -r /requirements/local.txt \
+  && apk del build-tools \
+  && apk del build-headers \
+  && rm -rf /root/.cache \
+  && rm -rf /usr/lib/python3.8 \
+  && rm -f /usr/lib/libpython3.* \
+  && rm -f /usr/lib/libxml2.* \
+  && rm -f /usr/lib/libstdc++.*
+
 RUN mkdir -p /app/config
 RUN mkdir -p /app/host
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/python:3.9
+FROM arm32v7/python:3.9-alpine
 
 RUN mkdir -p /app/config
 RUN mkdir -p /app/host


### PR DESCRIPTION
Error:

Building monitoring
Sending build context to Docker daemon  405.5kB
Step 1/9 : FROM arm32v7/python:3.9
3.9: Pulling from arm32v7/python
no matching manifest for linux/arm64/v8 in the manifest list entries